### PR TITLE
Fix discriminator with special character and default

### DIFF
--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -889,6 +889,94 @@ describe('JavaGenerator', () => {
     });
   });
 
+  describe('renders discriminator containing a special character', () => {
+    test('when discriminator has a default', async () => {
+      // note: the default discriminator value is not used in the output. See JacksonPreset.spec.ts for that.
+
+      const asyncapiDoc = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Pet example',
+          version: '1.0.0'
+        },
+        channels: {
+          pet: {
+            address: 'pet',
+            messages: {
+              Pet: {
+                $ref: '#/components/messages/Pet'
+              }
+            }
+          }
+        },
+        operations: {
+          petAvailable: {
+            action: 'receive',
+            channel: {
+              $ref: '#/channels/pet'
+            }
+          }
+        },
+        components: {
+          messages: {
+            Pet: {
+              payload: {
+                schema: {
+                  $ref: '#/components/schemas/Pet'
+                }
+              }
+            }
+          },
+          schemas: {
+            Pet: {
+              title: 'Pet',
+              type: 'object',
+              properties: {
+                "@type": {
+                  type: 'string',
+                  default: 'Fish'
+                }
+              },
+              required: ['@type'],
+              discriminator: '@type',
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Fish'
+                },
+                {
+                  $ref: '#/components/schemas/Bird'
+                }
+              ]
+            },
+            Bird: {
+              title: 'Bird',
+              type: 'object',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Fish: {
+              title: 'Fish',
+              type: 'object',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            }
+          }
+        }
+      };
+      const generator = new JavaGenerator({
+        useModelNameAsConstForDiscriminatorProperty: true
+      });
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+  });
+
   describe('when collection type is list and unique items is true it should render a set', () => {
     test('should create a set for unique arrays', async () => {
       const asyncapiDoc = {

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1727,6 +1727,37 @@ Array [
 ]
 `;
 
+exports[`JavaGenerator renders discriminator containing a special character when discriminator has a default 1`] = `
+Array [
+  "/**
+ * Pet represents a union of types: Fish, Bird
+ */
+public interface Pet {
+  
+}",
+  "public class Fish implements Pet {
+  private String atType = \\"Fish\\";
+  private Map<String, Object> additionalProperties;
+
+  public String getAtType() { return this.atType; }
+  public void setAtType(String atType) { this.atType = atType; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "public class Bird implements Pet {
+  private String atType = \\"Fish\\";
+  private Map<String, Object> additionalProperties;
+
+  public String getAtType() { return this.atType; }
+  public void setAtType(String atType) { this.atType = atType; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+]
+`;
+
 exports[`JavaGenerator should not render optional imports when only required field 1`] = `
 "public class OtherClass {
   private String color;


### PR DESCRIPTION
## Description
Test case and fix for Java generator, when a discriminator has a special character, e.g. `"@type"` and a default.

## Related Issue
https://github.com/asyncapi/modelina/issues/2332

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [ ] All tests pass successfully locally.(`npm run test`).

## Additional Notes
Fix to be implemented, test result to change from as-is to fixed.